### PR TITLE
Fix tiled authentication

### DIFF
--- a/data_validation.py
+++ b/data_validation.py
@@ -2,7 +2,7 @@ from prefect import task, flow, get_run_logger
 import time as ttime
 from tiled.client import from_profile
 
-tiled_client = from_profile("nsls2", username=None)
+tiled_client = from_profile("nsls2")
 
 @task(retries=2, retry_delay_seconds=10)
 def read_all_streams(beamline_acronym, uid):

--- a/export.py
+++ b/export.py
@@ -48,7 +48,7 @@ def export_task(uids):
     logger.info(f"Uids: {uids}")
 
     # Connect to the tiled server, and get the set of runs from the set of uids.
-    tiled_client = databroker.from_profile("nsls2", username=None)["lix"]["raw"]
+    tiled_client = databroker.from_profile("nsls2")["lix"]["raw"]
     runs = [tiled_client[uid] for uid in uids]
     task_info = {run.start["uid"]: run.start["plan_name"] for run in runs}
 


### PR DESCRIPTION
Specifying `username=None` in `from_profile` caused tiled to error out because both a tiled API key and username are provided.